### PR TITLE
Iteration #3 of carpool algorithm implementing Caching functions and minor fix to carpool Scoring

### DIFF
--- a/backend/routes/cacheUtil.js
+++ b/backend/routes/cacheUtil.js
@@ -1,0 +1,85 @@
+const routeCache = new Map();
+const distanceCache = new Map();
+const attendeeCache = new Map();
+
+const CACHE_TTL = 5 * 60 * 1000;
+
+function generateCacheKey(...args) {
+  return args
+    .map((arg) => (typeof arg === "object" ? JSON.stringify(arg) : String(arg)))
+    .join("|");
+}
+
+function getCachedValue(cache, key) {
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    return cached.value;
+  }
+  return null;
+}
+
+function setCachedValue(cache, key, value) {
+  cache.set(key, { value, timestamp: Date.now() });
+}
+
+function cleanupCache(cache) {
+  const now = Date.now();
+  for (const [key, entry] of cache.enteries()) {
+    if (now - entry.timestamp > CACHE_TTL) {
+      cache.delete(key);
+    }
+  }
+}
+
+function clearAllCaches() {
+  cleanupCache(routeCache);
+  cleanupCache(distanceCache);
+  cleanupCache(attendeeCache);
+}
+
+function cacheRoute(key, routeData) {
+  setCachedValue(routeCache, key, routeData);
+}
+
+function getCacheRoute(key) {
+  getCachedValue(routeCache, key);
+}
+
+function cacheDistance(key, distanceData) {
+  setCachedValue(distanceCache, key, distanceData);
+}
+
+function getCacheDistance(key) {
+  getCachedValue(distanceCache, key);
+}
+
+function cacheAttendee(key, attendeeData) {
+  setCachedValue(attendeeCache, key, attendeeData);
+}
+
+function getCacheAttendee(key) {
+  getCachedValue(routeCache, key);
+}
+
+function needsCleanup(cache) {
+  return cache.size > 1000;
+}
+
+module.exports = {
+  routeCache,
+  distanceCache,
+  attendeeCache,
+  generateCacheKey,
+  getCachedValue,
+  setCachedValue,
+  cleanupCache,
+  clearAllCaches,
+  cacheRoute,
+  getCacheRoute,
+  cacheDistance,
+  getCacheDistance,
+  cacheAttendee,
+  getCacheAttendee,
+  needsCleanup,
+  CACHE_TTL,
+};

--- a/backend/utils/carpoolScoring.js
+++ b/backend/utils/carpoolScoring.js
@@ -53,7 +53,7 @@ function calculateDurationScore(duration) {
 function calculatePassengerScore(passengerCount) {
   if (passengerCount === Infinity || passengerCount <= 0) return 0;
 
-  const thresholds = SCORING_THRESHOLDS.passengerCount;
+  const thresholds = SCORING_THRESHOLDS.passenger;
   if (passengerCount >= thresholds.max.max) return thresholds.max.score;
   if (passengerCount >= thresholds.good.max) return thresholds.good.score;
   return thresholds.poor.score;
@@ -62,7 +62,7 @@ function calculatePassengerScore(passengerCount) {
 function calculateTotalScore(distance, duration, passengerCount) {
   const distanceScore = calculateDistanceScore(distance);
   const durationScore = calculateDurationScore(duration);
-  const passengerScore = calculateDurationScore(passengerCount);
+  const passengerScore = calculatePassengerScore(passengerCount);
 
   const weightedScore =
     distanceScore * SCORING_WEIGHTS.distance +


### PR DESCRIPTION
### Details on changes

- I am trying to implement caching through creating maps and generating keys for routes, distance, and attendees.
- I created a keyGenerate method, getCachedValue, setCachedValue, and a caching function for routes, distance, and attendees.

### Context

My algorithm was running through every possible combination of drivers for similar passengers. By caching I could save memory for the cases were the best routes are the same.

### Testing

I will be using my carpool seeds and also using endpoints to ensure that the correct data is being cached.